### PR TITLE
feat(rollup-config): enable sourcemap generation by default (#54)

### DIFF
--- a/packages/rollup-config/src/RollupConfig.ts
+++ b/packages/rollup-config/src/RollupConfig.ts
@@ -50,10 +50,13 @@ export class RollupConfig<P extends Record<string, unknown>> {
     const {
       sourceDir,
       outputDir,
+      shouldGenerateSourcemaps,
       env = getCurrentEnv(),
       pluginBuilders: additionalPlugins,
       ...additionalOptions
     } = options;
+
+    const shouldGenerateSourcemap = shouldGenerateSourcemaps ?? true;
 
     const safeSourceDir = sourceDir ?? defaultSourceDir;
     const safeOutputDir = outputDir ?? defaultOutputDir;
@@ -71,7 +74,12 @@ export class RollupConfig<P extends Record<string, unknown>> {
     if (Array.isArray(outputOptions) && !outputDir)
       throw Error(`'outputDir' must be specified if 'RollupOptions.output' is an Array`);
 
-    const predicatedOutput = this.getOutput(rootDir, format, safeOutputDir);
+    const predicatedOutput = this.getOutput(
+      rootDir,
+      safeOutputDir,
+      shouldGenerateSourcemap,
+      format
+    );
     // If 'RollupOptions.output' turns out to be an Array, we have to iterate it and merge with 'predicatedOutput'.
     const output = Array.isArray(outputOptions)
       ? outputOptions.map((opts) => merge([predicatedOutput, opts]))
@@ -94,10 +102,12 @@ export class RollupConfig<P extends Record<string, unknown>> {
 
   protected readonly getOutput = (
     rootDir: string,
-    format: InternalModuleFormat,
-    outputDir: string
+    outputDir: string,
+    sourcemap: boolean,
+    format: InternalModuleFormat
   ): OutputOptions => ({
     format,
+    sourcemap,
     exports: 'auto',
     preserveModules: true,
     entryFileNames: `[name].[format].js`,

--- a/packages/rollup-config/src/types/RollupConfigFinalizeOptions.ts
+++ b/packages/rollup-config/src/types/RollupConfigFinalizeOptions.ts
@@ -22,4 +22,8 @@ export type RollupConfigFinalizeOptions<
    * Override plugin builder options.
    */
   readonly pluginBuilders?: RollupConfigPlugins<P>;
+  /**
+   * Indicate whether to generate sourcemaps. Defaults to `true`
+   */
+  readonly shouldGenerateSourcemaps?: boolean;
 };

--- a/packages/tests/src/rollup-config/RollupConfig.test.ts
+++ b/packages/tests/src/rollup-config/RollupConfig.test.ts
@@ -40,6 +40,7 @@ describe('RollupConfig', () => {
     expect(options.output).toStrictEqual({
       format,
       exports: 'auto',
+      sourcemap: true,
       entryFileNames: `[name].[format].js`,
       preserveModules: true,
       dir: pathToLib,


### PR DESCRIPTION
closes #54 