### PR TITLE
fix(rollup): use loadConfigFile from rollup/dist/shared to load configs (#41)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,9 +51,6 @@ build/Release
 node_modules/
 jspm_packages/
 
-# TypeScript v1 declaration files
-typings/
-
 # TypeScript cache
 *.tsbuildinfo
 

--- a/examples/mono-repo/colors/rollup.config.js
+++ b/examples/mono-repo/colors/rollup.config.js
@@ -1,3 +1,3 @@
-const { typescript } = require('@azimutlabs/rollup-config-typescript');
+import { typescript } from '@azimutlabs/rollup-config-typescript';
 
-module.exports = typescript()(__dirname);
+export default typescript()(__dirname);

--- a/examples/mono-repo/components/rollup.config.js
+++ b/examples/mono-repo/components/rollup.config.js
@@ -1,5 +1,5 @@
-const { combine } = require('@azimutlabs/rollup-config');
-const { babel } = require('@azimutlabs/rollup-config-babel');
-const { typescript } = require('@azimutlabs/rollup-config-typescript');
+import { combine } from '@azimutlabs/rollup-config';
+import { babel } from '@azimutlabs/rollup-config-babel';
+import { typescript } from '@azimutlabs/rollup-config-typescript';
 
-module.exports = combine(babel(), typescript())(__dirname);
+export default combine(babel(), typescript())(__dirname);

--- a/packages/rollup/src/collect.ts
+++ b/packages/rollup/src/collect.ts
@@ -1,5 +1,5 @@
 import { sync } from 'glob';
-import { extname } from 'path';
+import { extname, resolve } from 'path';
 import type { InternalModuleFormat, RollupOptions } from 'rollup';
 import loadConfigFile from 'rollup/dist/loadConfigFile';
 
@@ -17,7 +17,7 @@ export const collect = async (
     .flatMap((pattern) => sync(pattern, { cwd }) as readonly string[])
     .map(async (file) => {
       const format = formatByExtname[extname(file)];
-      const { warnings, options } = await loadConfigFile(file, { format });
+      const { warnings, options } = await loadConfigFile(resolve(cwd, file), { format });
 
       warnings.flush();
 

--- a/packages/rollup/src/typings/loadConfigFile.d.ts
+++ b/packages/rollup/src/typings/loadConfigFile.d.ts
@@ -1,0 +1,25 @@
+declare module 'rollup/dist/loadConfigFile' {
+  import type { OutputOptions, RollupOptions } from 'rollup';
+
+  export type BatchedWarnings = {
+    readonly count: number;
+    readonly flush: () => void;
+  };
+
+  export type LoadConfigFileResult = {
+    readonly warnings: BatchedWarnings;
+    readonly options: readonly RollupOptions[];
+  };
+
+  /**
+   * @param fileName - path to config.
+   * @param commandOptions - should be command line options. OutputOption is an alternative.
+   * @private
+   */
+  function loadConfigFile(
+    fileName: string,
+    commandOptions?: OutputOptions
+  ): Promise<LoadConfigFileResult>;
+
+  export = loadConfigFile;
+}

--- a/packages/tests/src/rollup/packages/b/rollup.config.js
+++ b/packages/tests/src/rollup/packages/b/rollup.config.js
@@ -2,7 +2,7 @@ const config = {
   input: 'b.js',
   output: {
     file: 'b.js',
-    format: 'esnext',
+    format: 'esm',
   },
 };
 

--- a/packages/tests/src/rollup/rollup.test.ts
+++ b/packages/tests/src/rollup/rollup.test.ts
@@ -1,8 +1,9 @@
 import { collect, fromWorkspaces, sortDependencies } from '@azimutlabs/rollup';
 import { Graph } from '@azimutlabs/rollup/lib/graph';
 import { resolve } from 'path';
+import type { NormalizedOutputOptions, RollupOptions } from 'rollup';
 
-const result = [
+const result: readonly RollupOptions[] = [
   {
     input: 'a.js',
     output: {
@@ -14,7 +15,7 @@ const result = [
     input: 'b.js',
     output: {
       file: 'b.js',
-      format: 'esnext',
+      format: 'esm',
     },
   },
   {
@@ -47,10 +48,21 @@ const result = [
   },
 ];
 
+const getMeaningfulConfig = (config: RollupOptions = {}): RollupOptions => {
+  const [output] = config.output as readonly NormalizedOutputOptions[];
+  return {
+    input: config.input,
+    output: {
+      file: output.file,
+      format: output.format,
+    },
+  };
+};
+
 describe('rollup', () => {
   it('collect should work properly', async () => {
     const config = await collect(['**/rollup.config.js']);
-    expect(config).toStrictEqual(result);
+    expect(config.map(getMeaningfulConfig)).toStrictEqual(result);
   });
 
   it('graph should work', () => {
@@ -136,6 +148,6 @@ describe('rollup', () => {
 
   it('collect should work with fromWorkspaces', async () => {
     const config = await collect(fromWorkspaces('packages/*/rollup.config.js'));
-    expect(config).toStrictEqual(result);
+    expect(config.map(getMeaningfulConfig)).toStrictEqual(result);
   });
 });


### PR DESCRIPTION
closes #41 