### PR TITLE
refactor(rollup-config)!: change combine arguments to receive finalizers instead of configs (#68)

### DIFF
--- a/examples/mono-repo/components/rollup.config.js
+++ b/examples/mono-repo/components/rollup.config.js
@@ -2,4 +2,4 @@ import { combine } from '@azimutlabs/rollup-config';
 import { babel } from '@azimutlabs/rollup-config-babel';
 import { typescript } from '@azimutlabs/rollup-config-typescript';
 
-export default combine(babel(), typescript());
+export default combine([babel, typescript]);

--- a/examples/typescript-babel/rollup.config.js
+++ b/examples/typescript-babel/rollup.config.js
@@ -2,4 +2,4 @@ import { combine, compose } from '@azimutlabs/rollup-config';
 import { babel } from '@azimutlabs/rollup-config-babel';
 import { typescript } from '@azimutlabs/rollup-config-typescript';
 
-export default compose(babel('cjs'), combine(babel(), typescript()));
+export default compose(babel('cjs'), combine([babel, typescript]));

--- a/packages/rollup-config/src/RollupConfig.ts
+++ b/packages/rollup-config/src/RollupConfig.ts
@@ -58,7 +58,7 @@ export class RollupConfig<P extends Record<string, unknown>> {
 
   public finalize(options?: RollupConfigFinalizeOptions<P>): RollupConfigFinalize;
   public finalize(
-    format: InternalModuleFormat,
+    format?: InternalModuleFormat,
     options?: RollupConfigFinalizeOptions<P>
   ): RollupConfigFinalize;
   public finalize(

--- a/packages/rollup-config/src/services/combine.ts
+++ b/packages/rollup-config/src/services/combine.ts
@@ -1,11 +1,20 @@
+import type { InternalModuleFormat } from 'rollup';
+
+import type { RollupConfig } from '../RollupConfig';
 import type { RollupConfigFinalize } from '../types/RollupConfigFinalize';
+import type { RollupConfigFinalizeOptions } from '../types/RollupConfigFinalizeOptions';
 import { merge } from './merge';
 
-export const combine = (
-  // eslint-disable-next-line functional/functional-parameters
-  ...configs: readonly [RollupConfigFinalize, ...(readonly RollupConfigFinalize[])]
-): RollupConfigFinalize => (dirname) => {
-  const [first, ...rest] = configs.map((cfg) => cfg(dirname));
+export const combine = <
+  P extends Record<string, unknown>,
+  C extends RollupConfig<P>['finalize'],
+  A extends Parameters<C>
+>(
+  finalizers: readonly C[],
+  format?: Extract<A[0], InternalModuleFormat>,
+  options?: Extract<A[1], RollupConfigFinalizeOptions<P>>
+): RollupConfigFinalize => (dirnameOrOptions) => {
+  const [first, ...rest] = finalizers.map((cfg) => cfg(format, options)(dirnameOrOptions));
   const config = merge([first, ...rest]);
   const configSet = new Set<string>();
   const plugins = config.plugins

--- a/packages/tests/src/rollup-config/combine.test.ts
+++ b/packages/tests/src/rollup-config/combine.test.ts
@@ -60,10 +60,7 @@ describe('combine', () => {
     const cfg1 = new RollupConfig(cfg1Plugins, cfg1Options);
     const cfg2 = new RollupConfig(cfg2Plugins, cfg2Options);
 
-    const cfg1Finalize = cfg1.finalize();
-    const cfg2Finalize = cfg2.finalize();
-
-    const rollupOptions = combine(cfg1Finalize, cfg2Finalize)(__dirname);
+    const rollupOptions = combine([cfg1.finalize.bind(cfg1), cfg2.finalize.bind(cfg2)])(__dirname);
 
     expect(rollupOptions.output).toStrictEqual(expectedMergeOptions.output);
     expect(rollupOptions.plugins).toStrictEqual([cfg1Plugin2, cfg2Plugin1]);


### PR DESCRIPTION
closes #68 